### PR TITLE
Limit timestep with viscosity-based diffusion bound

### DIFF
--- a/tau_hypersonic_cuda.cu
+++ b/tau_hypersonic_cuda.cu
@@ -1470,7 +1470,16 @@ int main(int argc, char **argv) {
         if (!isfinite(maxs) || maxs < 1e-12)
           maxs = 1e-12;
 
-        double dt = h_cfg.cfl * 1.0 / maxs; // dx=dy=1
+        double dt_convective = h_cfg.cfl * 1.0 / maxs; // dx=dy=1
+
+        double nu_max = fmax(h_cfg.visc_nu, fmax(h_cfg.visc_rho, h_cfg.visc_e));
+        double dt_diff = dt_convective;
+        if (isfinite(nu_max) && nu_max > 1e-12) {
+          // Explicit 2D diffusion stability limit for dx=dy=1.
+          dt_diff = 0.25 / nu_max;
+        }
+
+        double dt = fmin(dt_convective, dt_diff);
         double dt_dx = dt;
         double dt_dy = dt;
         double half_dt_dx = 0.5 * dt_dx;


### PR DESCRIPTION
### Motivation
- Prevent unstable explicit diffusion when physical viscosities are non-negligible by capping the timestep with an explicit diffusion stability limit computed from the largest viscosity coefficient.
- Preserve existing convective CFL behavior and the existing `maxs` floor so diffusion limiting is effectively disabled when viscosities are tiny or not finite.

### Description
- Replace the single convective `dt` with `dt_convective = h_cfg.cfl * 1.0 / maxs` and compute `nu_max = max(h_cfg.visc_nu, h_cfg.visc_rho, h_cfg.visc_e)`.
- Compute a diffusion stability limit `dt_diff = 0.25 / nu_max` for explicit 2D diffusion (for `dx=dy=1`) and only apply it when `nu_max` is finite and greater than `1e-12`.
- Set the final timestep with `dt = min(dt_convective, dt_diff)` and keep `dt_dx`, `dt_dy`, and half-step values unchanged.
- Change is localized to the simulation loop in `tau_hypersonic_cuda.cu` and preserves prior behavior when viscosities are near zero.

### Testing
- Inspected the source diff to verify the timestep logic change in `main` and sanity-checked surrounding uses of `dt` via static review (success).
- Committed the change locally with `git` (commit succeeded).
- Attempted to verify compilation with `nvcc --version`, but `nvcc` is not available in this environment so binary build/run could not be performed (failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1b96e2588328922c182ef89a084d)