### PR TITLE
Reduce unnecessary CUDA synchronizations in hypersonic main loop

### DIFF
--- a/tau_hypersonic_cuda.cu
+++ b/tau_hypersonic_cuda.cu
@@ -1458,7 +1458,6 @@ int main(int argc, char **argv) {
         k_step<<<blocksN, threads>>>(dU, dUtmp, dMask, dXFlux, dYFlux, dt,
                                      dt_dx, dt_dy);
         CK(cudaGetLastError());
-        CK(cudaDeviceSynchronize());
 
         // Ping-pong swap (removes k_copy full-grid copy)
         swap_Us(&dU, &dUtmp);
@@ -1471,7 +1470,6 @@ int main(int argc, char **argv) {
     k_render_vals<<<blocksN, threads>>>(dU, dMask, view_mode, dTmpVal,
                                         dBlockMin, dBlockMax);
     CK(cudaGetLastError());
-    CK(cudaDeviceSynchronize());
 
     const double *curMin = dBlockMin;
     const double *curMax = dBlockMax;
@@ -1497,6 +1495,7 @@ int main(int argc, char **argv) {
     k_render_pixels<<<blocksN, threads>>>(dMask, dTmpVal, curMin, dInvRange,
                                           dPixels);
     CK(cudaGetLastError());
+
     CK(cudaDeviceSynchronize());
 
     CK(cudaMemcpy(pixels, dPixels, (size_t)N * sizeof(uchar4),


### PR DESCRIPTION
### Motivation
- Reduce host-side stalls by removing unnecessary `cudaDeviceSynchronize()` calls while retaining kernel launch validation via `CK(cudaGetLastError())`.
- Preserve correctness by synchronizing only where the host consumes device results (reading `dMaxSpeed` and copying final rendered pixels).

### Description
- Removed `CK(cudaDeviceSynchronize())` after `k_step` inside the `for (int k = 0; k < h_cfg.steps_per_frame; k++)` loop so per-step solver kernels remain asynchronous.
- Removed the intermediate render synchronization after `k_render_vals` and retained a single `CK(cudaDeviceSynchronize())` before the host-side pixel copy from `dPixels`.
- Kept `CK(cudaGetLastError())` after every kernel launch and retained the synchronization before copying `dMaxSpeed` to host to ensure deterministic host reads.

### Testing
- Verified the source changes with `git diff` to confirm the modifications were limited to synchronization placements in `tau_hypersonic_cuda.cu`.
- Attempted to run CUDA tooling (`nvidia-smi` and `nvcc --version`) for profiling and throughput measurement but both tools are unavailable in this environment, so runtime profiling could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1e27c54c83288ba127913bef98ae)