### PR TITLE
Introduce local pi constant and replace PI in tau_hypersonic_cuda.cu

### DIFF
--- a/tau_hypersonic_cuda.cu
+++ b/tau_hypersonic_cuda.cu
@@ -32,6 +32,8 @@
 #define EPS_RHO 1e-25
 #define EPS_P 1e-25
 
+constexpr double kPi = 3.14159265358979323846;
+
 struct SimConfig {
   double gamma;
   double cfl;
@@ -1210,7 +1212,7 @@ static SimConfig default_config() {
   cfg.geom_cy = (double)H / 2.0;
   cfg.geom_Rb = (double)H / 12.0;
   cfg.geom_Rn = (double)H / 24.0;
-  cfg.geom_theta = PI / 4.0;
+  cfg.geom_theta = kPi / 4.0;
   cfg.steps_per_frame = 2;
   return cfg;
 }
@@ -1298,7 +1300,7 @@ static bool parse_args(int argc, char **argv, SimConfig *cfg) {
       cfg->visc_rho < 0.0 || cfg->visc_e < 0.0 || cfg->inflow_mach <= 0.0 ||
       cfg->steps_per_frame <= 0 || cfg->steps_per_frame > max_steps_per_frame ||
       cfg->geom_Rb <= 0.0 || cfg->geom_Rn <= 0.0 ||
-      cfg->geom_theta <= 0.0 || cfg->geom_theta >= 0.5 * PI) {
+      cfg->geom_theta <= 0.0 || cfg->geom_theta >= 0.5 * kPi) {
     fprintf(stderr, "Invalid physical/geometry config values.\n");
     return false;
   }


### PR DESCRIPTION
### Motivation
- Ensure non-UI code in `tau_hypersonic_cuda.cu` does not depend on Raylib-provided `PI` macro and centralize the pi value for local usage.

### Description
- Add a file-scope `constexpr double kPi = 3.14159265358979323846;` immediately after the existing `EPS_*` constants.
- Replace the default `cfg.geom_theta = PI / 4.0;` with `cfg.geom_theta = kPi / 4.0;` in `default_config()`.
- Replace the config validation upper bound `0.5 * PI` with `0.5 * kPi` to remove reliance on Raylib math macros in non-UI code paths.

### Testing
- Ran `rg -n "\bPI\b|kPi" tau_hypersonic_cuda.cu` and confirmed `PI` is no longer referenced while `kPi` is present in the updated locations.
- Inspected the modified file regions with `nl -ba tau_hypersonic_cuda.cu | sed -n '28,42p;1208,1219p;1296,1307p'` to verify the insertion and replacements were applied as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1e1fb87c8328a2451541d36745c3)