### PR TITLE
Expand tau_hypersonic CUDA test coverage

### DIFF
--- a/tau_hypersonic_cuda_tests.cu
+++ b/tau_hypersonic_cuda_tests.cu
@@ -35,11 +35,47 @@ __global__ void k_test_roundtrip(double *out) {
   out[3] = q.p;
 }
 
+__global__ void k_test_clamps(double *out) {
+  Prim badp{-2.0, 1.5, -0.5, -7.0};
+  Cons c = prim_to_cons(badp);
+  Prim q = cons_to_prim(Cons{1.0, 3.0, 4.0, 1e-20});
+
+  out[0] = c.rho;
+  out[1] = c.E;
+  out[2] = q.rho;
+  out[3] = q.p;
+}
+
 __global__ void k_test_limiters(double *out) {
   out[0] = minmod(1.0, 2.0);
   out[1] = minmod(-1.0, 2.0);
   out[2] = mc_limiter(1.0, 1.2, 1.5);
   out[3] = mc_limiter(-1.0, 0.2, 1.0);
+}
+
+__global__ void k_test_fluxes_and_sound(double *out) {
+  Prim p{2.0, 3.0, -4.0, 5.0};
+  Cons U = prim_to_cons(p);
+  Cons Fx = flux_x(U);
+  Cons Fy = flux_y(U);
+
+  out[0] = Fx.rho;
+  out[1] = Fx.mx;
+  out[2] = Fx.my;
+  out[3] = Fx.E;
+  out[4] = Fy.rho;
+  out[5] = Fy.mx;
+  out[6] = Fy.my;
+  out[7] = Fy.E;
+  out[8] = sound_speed(p);
+}
+
+__global__ void k_test_inflow_state(double *out) {
+  Prim infl = inflow_state();
+  out[0] = infl.rho;
+  out[1] = infl.u;
+  out[2] = infl.v;
+  out[3] = infl.p;
 }
 
 __global__ void k_test_hllc_consistency(double *out) {
@@ -72,6 +108,18 @@ __global__ void k_test_enforce_positive(double *out) {
   out[3] = qp.p;
 }
 
+__global__ void k_test_enforce_positive_no_change(double *out) {
+  Prim qc{1.0, 2.0, -1.0, 1.0};
+  Prim qm{0.8, 2.2, -0.9, 1.1};
+  Prim qp{1.2, 1.8, -1.2, 0.9};
+  enforce_positive_faces(qm, qc, qp);
+
+  out[0] = qm.rho;
+  out[1] = qm.p;
+  out[2] = qp.rho;
+  out[3] = qp.p;
+}
+
 __global__ void k_test_sdf(double *out) {
   double Rb = 5.0;
   double Rn = 2.0;
@@ -93,8 +141,23 @@ __global__ void k_test_neighbors(Usoa U, const uint8_t *mask, double *out,
   out[4] = up.mx;
 }
 
+__global__ void k_test_neighbor_for_diff(Usoa U, const uint8_t *mask,
+                                         double *out, int x, int y) {
+  Cons left = neighbor_for_diff(U, mask, x, y, x - 1, y);
+  Cons wall = neighbor_for_diff(U, mask, x, y, x, y + 1);
+  Cons top_clamped = neighbor_for_diff(U, mask, x, y, x, H + 20);
+
+  out[0] = left.rho;
+  out[1] = left.mx;
+  out[2] = wall.mx;
+  out[3] = top_clamped.rho;
+}
+
 int main() {
   TestStats stats{0, 0};
+
+  SimConfig cfg = default_config();
+  CK(cudaMemcpyToSymbol(d_cfg, &cfg, sizeof(SimConfig)));
 
   double *d = nullptr;
   CK(cudaMalloc(&d, 16 * sizeof(double)));
@@ -108,6 +171,15 @@ int main() {
   CHECK_NEAR(stats, h[2], -0.7, 1e-12, "cons/prim roundtrip preserves v");
   CHECK_NEAR(stats, h[3], 3.6, 1e-12, "cons/prim roundtrip preserves p");
 
+  k_test_clamps<<<1, 1>>>(d);
+  CK(cudaDeviceSynchronize());
+  CK(cudaMemcpy(h, d, 4 * sizeof(double), cudaMemcpyDeviceToHost));
+  CHECK_NEAR(stats, h[0], EPS_RHO, 1e-30, "prim_to_cons clamps rho floor");
+  CHECK_TRUE(stats, h[1] >= EPS_P / (cfg.gamma - 1.0),
+             "prim_to_cons keeps positive internal energy");
+  CHECK_NEAR(stats, h[2], 1.0, 1e-12, "cons_to_prim keeps positive rho");
+  CHECK_TRUE(stats, h[3] >= EPS_P, "cons_to_prim clamps pressure floor");
+
   k_test_limiters<<<1, 1>>>(d);
   CK(cudaDeviceSynchronize());
   CK(cudaMemcpy(h, d, 4 * sizeof(double), cudaMemcpyDeviceToHost));
@@ -117,6 +189,29 @@ int main() {
              "mc limiter bounded for monotone stencil");
   CHECK_NEAR(stats, h[3], 0.0, 1e-15,
              "mc limiter returns zero across sign change");
+
+  k_test_fluxes_and_sound<<<1, 1>>>(d);
+  CK(cudaDeviceSynchronize());
+  CK(cudaMemcpy(h, d, 9 * sizeof(double), cudaMemcpyDeviceToHost));
+  CHECK_NEAR(stats, h[0], 6.0, 1e-12, "flux_x rho equals rho*u");
+  CHECK_NEAR(stats, h[1], 23.0, 1e-12, "flux_x mx equals rho*u^2+p");
+  CHECK_NEAR(stats, h[2], -24.0, 1e-12, "flux_x my equals rho*u*v");
+  CHECK_NEAR(stats, h[3], 102.0, 1e-12, "flux_x E equals (E+p)u");
+  CHECK_NEAR(stats, h[4], -8.0, 1e-12, "flux_y rho equals rho*v");
+  CHECK_NEAR(stats, h[5], -24.0, 1e-12, "flux_y mx equals rho*u*v");
+  CHECK_NEAR(stats, h[6], 37.0, 1e-12, "flux_y my equals rho*v^2+p");
+  CHECK_NEAR(stats, h[7], -136.0, 1e-12, "flux_y E equals (E+p)v");
+  CHECK_NEAR(stats, h[8], std::sqrt(cfg.gamma * 5.0 / 2.0), 1e-12,
+             "sound speed matches ideal-gas formula");
+
+  k_test_inflow_state<<<1, 1>>>(d);
+  CK(cudaDeviceSynchronize());
+  CK(cudaMemcpy(h, d, 4 * sizeof(double), cudaMemcpyDeviceToHost));
+  CHECK_NEAR(stats, h[0], 1.0, 1e-12, "inflow rho matches default");
+  CHECK_NEAR(stats, h[1], cfg.inflow_mach * std::sqrt(cfg.gamma), 1e-12,
+             "inflow u equals mach * sound speed");
+  CHECK_NEAR(stats, h[2], 0.0, 1e-12, "inflow v is zero");
+  CHECK_NEAR(stats, h[3], 1.0, 1e-12, "inflow p matches default");
 
   k_test_hllc_consistency<<<1, 1>>>(d);
   CK(cudaDeviceSynchronize());
@@ -133,6 +228,18 @@ int main() {
   CHECK_TRUE(stats, h[1] >= EPS_P, "enforce_positive_faces keeps qm p > 0");
   CHECK_TRUE(stats, h[2] >= EPS_RHO, "enforce_positive_faces keeps qp rho > 0");
   CHECK_TRUE(stats, h[3] >= EPS_P, "enforce_positive_faces keeps qp p > 0");
+
+  k_test_enforce_positive_no_change<<<1, 1>>>(d);
+  CK(cudaDeviceSynchronize());
+  CK(cudaMemcpy(h, d, 4 * sizeof(double), cudaMemcpyDeviceToHost));
+  CHECK_NEAR(stats, h[0], 0.8, 1e-12,
+             "enforce_positive_faces keeps valid qm rho unchanged");
+  CHECK_NEAR(stats, h[1], 1.1, 1e-12,
+             "enforce_positive_faces keeps valid qm p unchanged");
+  CHECK_NEAR(stats, h[2], 1.2, 1e-12,
+             "enforce_positive_faces keeps valid qp rho unchanged");
+  CHECK_NEAR(stats, h[3], 0.9, 1e-12,
+             "enforce_positive_faces keeps valid qp p unchanged");
 
   k_test_sdf<<<1, 1>>>(d);
   CK(cudaDeviceSynchronize());
@@ -186,6 +293,18 @@ int main() {
   CHECK_NEAR(stats, h[3], 7.0, 1e-12, "right neighbor uses fluid state");
   CHECK_NEAR(stats, h[4], -3.0, 1e-12,
              "masked neighbor reflects no-slip momentum");
+
+  k_test_neighbor_for_diff<<<1, 1>>>(U, dMask, d, x, y);
+  CK(cudaDeviceSynchronize());
+  CK(cudaMemcpy(h, d, 4 * sizeof(double), cudaMemcpyDeviceToHost));
+  CHECK_NEAR(stats, h[0], infl.rho, 1e-12,
+             "neighbor_for_diff left boundary uses inflow rho");
+  CHECK_NEAR(stats, h[1], prim_to_cons(infl).mx, 1e-10,
+             "neighbor_for_diff left boundary uses inflow mx");
+  CHECK_NEAR(stats, h[2], -3.0, 1e-12,
+             "neighbor_for_diff masked cell reflects momentum");
+  CHECK_NEAR(stats, h[3], 1.0, 1e-12,
+             "neighbor_for_diff clamps y index before lookup");
 
   free(hrho);
   free(hmx);


### PR DESCRIPTION
### Motivation
- Improve unit-test coverage for the CUDA hypersonic solver helpers by exercising primitive↔conservative conversions, limiter behavior, flux computations, sound speed, inflow state, positivity enforcement, neighbor lookup semantics, and the sdf helper.
- Ensure the device-side helpers in the test binary use the same simulation defaults as the runtime by initializing the device `SimConfig` so checks reflect real solver configuration.

### Description
- Added several new device test kernels: `k_test_clamps`, `k_test_fluxes_and_sound`, `k_test_inflow_state`, `k_test_enforce_positive_no_change`, and `k_test_neighbor_for_diff` to exercise clamping/floor behavior, flux formulas, sound speed, inflow-state generation, positivity limiter stability, and `neighbor_for_diff` boundary/mask/clamping logic.
- Initialized device configuration in the test executable by copying `default_config()` into `d_cfg` with `cudaMemcpyToSymbol` so device helpers use runtime defaults.
- Extended `main()` to invoke the new kernels and added assertions using `CHECK_TRUE`/`CHECK_NEAR` to validate numeric expectations for flux components, sound speed, clamping behavior, inflow properties, positivity enforcement, and neighbor behavior.

### Testing
- Attempted to compile the test binary with `nvcc -O3 -std=c++17 -o tau_hypersonic_cuda_tests tau_hypersonic_cuda_tests.cu`, but the compile could not run here because `nvcc` is not installed (error: `command not found`).
- No runtime CUDA tests were executed in this environment due to the missing CUDA toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a2088c4a4832890ed20e06b7d3494)