### PR TITLE
Unify CUDA deallocation for U/C buffers via checked free helper

### DIFF
--- a/tau_hypersonic_cuda.cu
+++ b/tau_hypersonic_cuda.cu
@@ -1362,12 +1362,13 @@ static void alloc_Us(Usoa *U, int N) {
   CK(cudaMalloc(&U->E, N * sizeof(double)));
 }
 
+static void free_cuda_ptr(void **ptr);
+
 static void free_Us(Usoa *U) {
-  cudaFree(U->rho);
-  cudaFree(U->mx);
-  cudaFree(U->my);
-  cudaFree(U->E);
-  U->rho = U->mx = U->my = U->E = nullptr;
+  free_cuda_ptr((void **)&U->rho);
+  free_cuda_ptr((void **)&U->mx);
+  free_cuda_ptr((void **)&U->my);
+  free_cuda_ptr((void **)&U->E);
 }
 
 static void free_cuda_ptr(void **ptr) {
@@ -1389,11 +1390,10 @@ static void alloc_Cs(Csoa *A, int N) {
 }
 
 static void free_Cs(Csoa *A) {
-  cudaFree(A->rho);
-  cudaFree(A->mx);
-  cudaFree(A->my);
-  cudaFree(A->E);
-  A->rho = A->mx = A->my = A->E = nullptr;
+  free_cuda_ptr((void **)&A->rho);
+  free_cuda_ptr((void **)&A->mx);
+  free_cuda_ptr((void **)&A->my);
+  free_cuda_ptr((void **)&A->E);
 }
 
 static inline void swap_Us(Usoa *a, Usoa *b) {


### PR DESCRIPTION
### Motivation
- Ensure all device-buffer deallocations report CUDA errors consistently and null pointers after free to avoid double-free/use-after-free risks.
- Consolidate cleanup behavior for the grouped U- and C-structured device buffers so reverse-order cleanup remains deterministic and uniform.

### Description
- Replaced direct `cudaFree` calls in `free_Us` with calls to the checked wrapper `free_cuda_ptr` so each field is freed via the same error-reporting path and nulled thereafter. 
- Replaced direct `cudaFree` calls in `free_Cs` with calls to `free_cuda_ptr` to achieve the same uniform behavior for C-structured buffers. 
- Added a forward declaration for `free_cuda_ptr` so the helper is available before `free_Us`/`free_Cs` definitions, and preserved the existing `free_cuda_ptr` implementation that logs warnings on `cudaFree` failure.
- Left the deterministic reverse-order cleanup in `main` unchanged so each `cudaMalloc` in `main` maps to a single checked free path (either `free_cuda_ptr` directly or via `free_Cs`/`free_Us`).

### Testing
- Ran pattern checks with `rg` to confirm the new usages of `free_cuda_ptr` and that `free_Us`/`free_Cs` no longer call `cudaFree` directly, and the search succeeded. 
- Inspected the edited source and diff to verify the forward declaration and replacements were applied to `tau_hypersonic_cuda.cu`, and the inspection succeeded. 
- Executed a small Python inspection script that enumerated `cudaMalloc` calls in `main` and matched them to the corresponding single checked free calls, and the script reported the expected mappings. 
- Performed a local file commit after verification to record the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a218d05188328b7e523fc4f41f461)