### PR TITLE
Use dynamic shared memory for CUDA reductions and add launch validation

### DIFF
--- a/tau_hypersonic_cuda.cu
+++ b/tau_hypersonic_cuda.cu
@@ -59,6 +59,36 @@ static inline void ck(cudaError_t e, const char *msg) {
 }
 #define CK(x) ck((x), #x)
 
+static void validate_reduction_launch_config(int threads,
+                                             size_t shared_bytes_per_array) {
+  if (threads <= 0 || (threads & (threads - 1)) != 0) {
+    fprintf(stderr,
+            "Invalid thread count %d: reductions require a positive power-of-two block size.\n",
+            threads);
+    exit(1);
+  }
+
+  int dev = 0;
+  CK(cudaGetDevice(&dev));
+  cudaDeviceProp prop{};
+  CK(cudaGetDeviceProperties(&prop, dev));
+
+  if (threads > prop.maxThreadsPerBlock) {
+    fprintf(stderr,
+            "Invalid thread count %d: device maxThreadsPerBlock is %d.\n",
+            threads, prop.maxThreadsPerBlock);
+    exit(1);
+  }
+
+  size_t shared_bytes = shared_bytes_per_array * (size_t)threads;
+  if (shared_bytes > prop.sharedMemPerBlock) {
+    fprintf(stderr,
+            "Invalid shared memory request %zu bytes: device sharedMemPerBlock is %zu bytes.\n",
+            shared_bytes, (size_t)prop.sharedMemPerBlock);
+    exit(1);
+  }
+}
+
 typedef struct {
   double *rho, *mx, *my, *E;
 } Usoa;
@@ -755,7 +785,7 @@ __global__ void k_apply_inflow_left(Usoa U, const uint8_t *mask) {
 
 __global__ void k_max_wavespeed_blocks(const Usoa U, const uint8_t *mask,
                                        double *blockMax) {
-  __shared__ double smax[256];
+  extern __shared__ double smax[];
   int tid = threadIdx.x;
   int N = W * H;
 
@@ -790,7 +820,7 @@ __global__ void k_max_wavespeed_blocks(const Usoa U, const uint8_t *mask,
 
 __global__ void k_reduce_block_max(const double *blockMax, int nBlocks,
                                    double *outMax) {
-  __shared__ double smax[256];
+  extern __shared__ double smax[];
   int tid = threadIdx.x;
   double vmax = 1e-12;
 
@@ -1201,8 +1231,9 @@ __global__ void k_step(Usoa U, Usoa Uout, const uint8_t *mask, Csoa xFlux,
 __global__ void k_render_vals(const Usoa U, const uint8_t *mask, int view_mode,
                               double *tmpVal, double *blockMin,
                               double *blockMax) {
-  __shared__ double smin[256];
-  __shared__ double smax[256];
+  extern __shared__ double sdata[];
+  double *smin = sdata;
+  double *smax = sdata + blockDim.x;
 
   int tid = threadIdx.x;
   int i = (int)(blockIdx.x * blockDim.x + tid);
@@ -1302,8 +1333,9 @@ __global__ void k_render_pixels(const uint8_t *mask, const double *tmpVal,
 
 __global__ void k_reduce_minmax(const double *inMin, const double *inMax,
                                 double *outMin, double *outMax, int n) {
-  __shared__ double smin[256];
-  __shared__ double smax[256];
+  extern __shared__ double sdata[];
+  double *smin = sdata;
+  double *smax = sdata + blockDim.x;
 
   int tid = threadIdx.x;
   int i0 = (int)(2 * blockIdx.x * blockDim.x + tid);
@@ -1580,6 +1612,10 @@ int main(int argc, char **argv) {
   CK(cudaMalloc(&dPixels, (size_t)N * sizeof(uchar4)));
 
   const int threads = 256;
+  const size_t reduceSharedBytes = (size_t)threads * sizeof(double);
+  const size_t reduceMinMaxSharedBytes = (size_t)threads * 2 * sizeof(double);
+  validate_reduction_launch_config(threads, 2 * sizeof(double));
+
   const int blocksN = (N + threads - 1) / threads;
   const int xFaceCount = (W + 1) * H;
   const int yFaceCount = W * (H + 1);
@@ -1643,10 +1679,11 @@ int main(int argc, char **argv) {
         CK(cudaGetLastError());
 
         // Two-stage GPU reduction to a single max wavespeed.
-        k_max_wavespeed_blocks<<<blocksN, threads>>>(dU, dMask,
-                                                     dBlockSpeedMax);
+        k_max_wavespeed_blocks<<<blocksN, threads, reduceSharedBytes>>>(
+            dU, dMask, dBlockSpeedMax);
         CK(cudaGetLastError());
-        k_reduce_block_max<<<1, threads>>>(dBlockSpeedMax, blocksN, dMaxSpeed);
+        k_reduce_block_max<<<1, threads, reduceSharedBytes>>>(dBlockSpeedMax,
+                                                        blocksN, dMaxSpeed);
         CK(cudaGetLastError());
         CK(cudaDeviceSynchronize());
 
@@ -1694,8 +1731,8 @@ int main(int argc, char **argv) {
     }
 
     // render pass A: vals + per-block min/max
-    k_render_vals<<<blocksN, threads>>>(dU, dMask, view_mode, dTmpVal,
-                                        dBlockMin, dBlockMax);
+    k_render_vals<<<blocksN, threads, reduceMinMaxSharedBytes>>>(
+        dU, dMask, view_mode, dTmpVal, dBlockMin, dBlockMax);
     CK(cudaGetLastError());
 
     const double *curMin = dBlockMin;
@@ -1705,7 +1742,8 @@ int main(int argc, char **argv) {
     int curN = blocksN;
     while (curN > 1) {
       int outN = (curN + (2 * threads - 1)) / (2 * threads);
-      k_reduce_minmax<<<outN, threads>>>(curMin, curMax, outMin, outMax, curN);
+      k_reduce_minmax<<<outN, threads, reduceMinMaxSharedBytes>>>(
+          curMin, curMax, outMin, outMax, curN);
       CK(cudaGetLastError());
       curN = outN;
       const double *nextMin = outMin;


### PR DESCRIPTION
### Motivation
- Remove hard-coded per-block shared-array sizes (256) used by multiple reduction and render kernels to avoid silent out-of-bounds when tuning `threads`/block sizes.
- Ensure host and device agree on shared-memory sizing and block size constraints so mis-configurations fail fast instead of causing subtle corruption.

### Description
- Replaced fixed-size shared arrays with dynamically-sized shared memory in `tau_hypersonic_cuda.cu` for the kernels `k_max_wavespeed_blocks`, `k_reduce_block_max`, `k_render_vals`, and `k_reduce_minmax` by switching to `extern __shared__` and splitting a single buffer for min/max where appropriate.
- Added `validate_reduction_launch_config(int threads, size_t shared_bytes_per_array)` to validate that reduction `threads` is a positive power-of-two, does not exceed the device `maxThreadsPerBlock`, and that the requested shared memory (computed as `shared_bytes_per_array * threads`) fits in `sharedMemPerBlock`.
- Updated host-side launch setup: computed `reduceSharedBytes` and `reduceMinMaxSharedBytes` and passed the byte-size explicitly to the affected kernel launches (`k_max_wavespeed_blocks`, `k_reduce_block_max`, `k_render_vals`, `k_reduce_minmax`).

### Testing
- Ran repository checks including `git diff --check` which passed.
- Performed local static inspections/grep to verify kernels and launches were updated to use dynamic shared memory and correct shared-byte arguments, which succeeded.
- Attempted to compile with `nvcc -std=c++17 -c tau_hypersonic_cuda.cu` but compilation could not be run because `nvcc` is not available in this environment (automated compile step failed due to missing tool).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a21878a2483289b49d54b1182041b)