### PR TITLE
Fix `k_schlieren` x-boundary handling to match solver diagnostics

### DIFF
--- a/tau_hypersonic_3d_cuda.cu
+++ b/tau_hypersonic_3d_cuda.cu
@@ -1174,12 +1174,14 @@ __global__ void k_schlieren(const float *xi, float *out) {
   if (x >= P.nx || y >= P.ny || z >= P.nz)
     return;
 
-  int xm = wrapi(x - 1, P.nx), xp = wrapi(x + 1, P.nx);
+  int xm = x - 1, xp = x + 1;
   int ym = wrapi(y - 1, P.ny), yp = wrapi(y + 1, P.ny);
   int zm = wrapi(z - 1, P.nz), zp = wrapi(z + 1, P.nz);
 
-  float rxm = rho_from_xi(xi[idx3(xm, y, z)]);
-  float rxp = rho_from_xi(xi[idx3(xp, y, z)]);
+  float rxm = (xm < 0) ? fmaxf(P.inflow_r, 1e-30f)
+                       : rho_from_xi(xi[idx3(xm, y, z)]);
+  float rxp = (xp >= P.nx) ? rho_from_xi(xi[idx3(P.nx - 1, y, z)])
+                           : rho_from_xi(xi[idx3(xp, y, z)]);
   float rym = rho_from_xi(xi[idx3(x, ym, z)]);
   float ryp = rho_from_xi(xi[idx3(x, yp, z)]);
   float rzm = rho_from_xi(xi[idx3(x, y, zm)]);


### PR DESCRIPTION
### Motivation
- `k_schlieren` previously used periodic wrapping in `x`, which caused artificial wraparound gradients at `x=0` and `x=nx-1` for non-periodic inflow/outflow setups and did not match the BC-aware convention used by solver diagnostics (`prim_at_xbc`).
- The change aligns the schlieren diagnostic with the solver's x-boundary convention to avoid misleading edge artifacts while keeping `y/z` periodic behavior unchanged.

### Description
- Updated `tau_hypersonic_3d_cuda.cu` in `k_schlieren` to stop using `wrapi(x +/- 1, P.nx)` and instead use direct neighbor indices `xm = x - 1` and `xp = x + 1` for the x-direction. 
- Implemented BC-aware density sampling for x-neighbors: left out-of-bounds (`xm < 0`) uses `fmaxf(P.inflow_r, 1e-30f)` (inflow), and right out-of-bounds (`xp >= P.nx`) clamps to `P.nx - 1` (zero-gradient outflow). 
- Left `y`/`z` neighbor handling remains periodic via `wrapi(y +/- 1, P.ny)` and `wrapi(z +/- 1, P.nz)`, preserving existing periodic behavior in those directions.
- The computed gradient `drdx` now uses these BC-aware samples so that schlieren no longer reads wrapped-around values from the opposite x-edge.

### Testing
- Ran targeted synthetic boundary-stencil checks with small Python scripts that compared the old periodic-x gradient (`old_drdx`) and the new BC-aware gradient (`new_drdx`) on representative arrays, and the scripts executed successfully. 
- The tests confirmed that previously wraparound-influenced edge gradients (e.g. values pulled from `x=0` into `x=nx-1`) are removed and that `x=nx-1` no longer shows artificial coupling to `x=0`. 
- No automated compile/test suite was run in this rollout; the change was limited to the diagnostic kernel and validated via the above numeric checks which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b7549c39c832899b236e07b24370e)