### PR TITLE
Recompute inflow gain inside per-step simulation loop

### DIFF
--- a/tau_hypersonic_3d_cuda.cu
+++ b/tau_hypersonic_3d_cuda.cu
@@ -1295,9 +1295,7 @@ int main() {
   int zslice = hp.nz / 2;
   bool paused = false;
   bool log_scale = true;
-  float ramp = t / 0.02f;
   float a_gain = 0.55f; // opacity
-  float inflow_gain = fminf(fmaxf(ramp, 0.f), 1.f);
   int z_stride = 1; // 1=all slices, 2=half, 3=third
   const int steps_per_frame = 2;
 
@@ -1337,6 +1335,8 @@ int main() {
       for (int s = 0; s < steps_per_frame; s++) {
         t *= expf(d_tau);
         dt = t * d_tau;
+        float ramp = t / 0.02f;
+        float inflow_gain = fminf(fmaxf(ramp, 0.f), 1.f);
 
         float zero = 0.f;
         ck(cudaMemcpy(d_maxs, &zero, sizeof(float), cudaMemcpyHostToDevice),


### PR DESCRIPTION
### Motivation
- Ensure the inflow driving amplitude is computed from the current simulation time each substep so `k_step` receives an up-to-date, clamped `inflow_gain` and avoid accidental reuse of a stale outer-scope variable.

### Description
- Removed the outer-scope `ramp`/`inflow_gain` and instead compute `ramp = t / 0.02f` and `inflow_gain = fminf(fmaxf(ramp, 0.f), 1.f)` immediately after updating `t`/`dt` inside the `for (int s = 0; s < steps_per_frame; s++)` loop and pass the per-step `inflow_gain` into `k_step`.

### Testing
- Performed quick automated repository checks including `git diff`, `git status`, and inspected the host loop with `nl` to confirm the per-step computation and `k_step` launch; no build/unit tests were run in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b8c9de82c83289dbca86ab9fd3af7)