### PR TITLE
Use characteristic outflow states in k_step halo preload

### DIFF
--- a/tau_hypersonic_3d_cuda.cu
+++ b/tau_hypersonic_3d_cuda.cu
@@ -974,9 +974,11 @@ __global__ void k_step(const float *xi, const float *phix, const float *phiy,
     Prim q;
     if (gx < 0) {
       q = inflow_prim();
+    } else if (gx >= P.nx) {
+      q = outflow_prim_characteristic(xi, phix, phiy, phiz, lam, zet, gx, gyw,
+                                      gzw);
     } else {
-      int gxc = (gx >= P.nx) ? (P.nx - 1) : gx;
-      int gi = idx3(gxc, gyw, gzw);
+      int gi = idx3(gx, gyw, gzw);
       q = log_to_prim(xi[gi], phix[gi], phiy[gi], phiz[gi], lam[gi], zet[gi]);
     }
     if (is_solid)


### PR DESCRIPTION
### Motivation
- Ensure right-side halo ghost states consumed by WENO reconstructions and HLLC fluxes are boundary-condition consistent by using a characteristic outflow extrapolation instead of clamping to `P.nx - 1`.

### Description
- In the `k_step` shared-memory halo preload loop, handle `gx >= P.nx` by calling `outflow_prim_characteristic(xi, phix, phiy, phiz, lam, zet, gx, gyw, gzw)`, keep `gx < 0` mapped to `inflow_prim()`, keep interior `0 <= gx < P.nx` using `log_to_prim(...)`, and preserve `apply_wall(q)` for solid cells.

### Testing
- Ran automated static checks with `rg` to confirm insertion of the `outflow_prim_characteristic` call and inspected the source change with `git diff`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b9115aa3c83288f9e382ce9618c2d)