### PR TITLE
Add build CI and repair the hypersonic CUDA test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  cpu:
+    name: Build CPU demos (gcc)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential libraylib-dev libncurses-dev \
+            libgl1-mesa-dev libx11-dev
+
+      - name: Build
+        run: make cpu
+
+  cuda:
+    name: Build CUDA demos + tests (nvcc)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install CUDA toolkit
+        uses: Jimver/cuda-toolkit@v0.2.19
+        with:
+          method: network
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            g++-12 libraylib-dev libncurses-dev \
+            libgl1-mesa-dev libx11-dev
+
+      # nvcc can compile and link the CUDA demos and the test harness without a
+      # GPU present; only running the test binary needs a device.
+      - name: Build CUDA demos
+        run: make cuda CCBIN=g++-12
+
+      - name: Build test harness
+        run: make tau_hypersonic_cuda_tests
+
+      - name: Run regression + unit tests (only if a GPU is available)
+        run: |
+          if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi >/dev/null 2>&1; then
+            make test
+          else
+            echo "No CUDA-capable GPU on this runner; tests were compiled but not executed."
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  RAYLIB_VERSION: 5.5.0
+
 jobs:
   cpu:
     name: Build CPU demos (gcc)
@@ -15,12 +18,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
+      - name: Install apt dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            build-essential libraylib-dev libncurses-dev \
+            build-essential libncurses-dev \
             libgl1-mesa-dev libx11-dev
+
+      # raylib is not packaged in Ubuntu's repos, so install the official
+      # prebuilt release into /usr/local.
+      - name: Install raylib
+        run: |
+          set -e
+          curl -fsSL -o raylib.tar.gz \
+            "https://github.com/raysan5/raylib/releases/download/${RAYLIB_VERSION}/raylib-${RAYLIB_VERSION}_linux_amd64.tar.gz"
+          mkdir raylib-pkg
+          tar -xzf raylib.tar.gz -C raylib-pkg --strip-components=1
+          sudo cp -r raylib-pkg/include/* /usr/local/include/
+          sudo cp -r raylib-pkg/lib/* /usr/local/lib/
+          sudo ldconfig
 
       - name: Build
         run: make cpu
@@ -31,25 +47,38 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Install only the compiler and runtime; the full meta-package would pull
+      # in the NVIDIA driver, which cannot build on a runner without a GPU.
       - name: Install CUDA toolkit
         uses: Jimver/cuda-toolkit@v0.2.19
         with:
+          cuda: "12.6.3"
           method: network
+          sub-packages: '["nvcc", "cudart", "cudart-dev"]'
 
-      - name: Install dependencies
+      - name: Install apt dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            g++-12 libraylib-dev libncurses-dev \
+            build-essential libncurses-dev \
             libgl1-mesa-dev libx11-dev
 
-      # nvcc can compile and link the CUDA demos and the test harness without a
-      # GPU present; only running the test binary needs a device.
-      - name: Build CUDA demos
-        run: make cuda CCBIN=g++-12
+      - name: Install raylib
+        run: |
+          set -e
+          curl -fsSL -o raylib.tar.gz \
+            "https://github.com/raysan5/raylib/releases/download/${RAYLIB_VERSION}/raylib-${RAYLIB_VERSION}_linux_amd64.tar.gz"
+          mkdir raylib-pkg
+          tar -xzf raylib.tar.gz -C raylib-pkg --strip-components=1
+          sudo cp -r raylib-pkg/include/* /usr/local/include/
+          sudo cp -r raylib-pkg/lib/* /usr/local/lib/
+          sudo ldconfig
 
-      - name: Build test harness
-        run: make tau_hypersonic_cuda_tests
+      # nvcc can compile and link the CUDA demos and the test harness without a
+      # GPU present; only running the test binary needs a device. Use the
+      # runner's default g++ as the host compiler.
+      - name: Build CUDA demos + tests
+        run: make cuda CCBIN=g++
 
       - name: Run regression + unit tests (only if a GPU is available)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  RAYLIB_VERSION: 5.5.0
+  RAYLIB_VERSION: "5.5"
 
 jobs:
   cpu:
@@ -52,7 +52,6 @@ jobs:
       - name: Install CUDA toolkit
         uses: Jimver/cuda-toolkit@v0.2.19
         with:
-          cuda: "12.6.3"
           method: network
           sub-packages: '["nvcc", "cudart", "cudart-dev"]'
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@
 CC      = gcc
 NVCC    = nvcc
 
+# Host compiler nvcc hands C++ off to (overridable for CI).
+CCBIN   ?= g++-10
+
 # ---------------------------------------------------------------------------
 # Binaries
 # ---------------------------------------------------------------------------
@@ -25,10 +28,19 @@ CUDA_BINS := jsc jsc3d tau_burgers tgs tau3d tau_2d_hypersonic_cuda \
 # th3cs also needs 4splat.c, so it is kept out of the default group and built
 # explicitly with `make th3cs`.
 
-.PHONY: all cpu cuda clean
+.PHONY: all cpu cuda test clean
 all: cpu cuda
 cpu: $(CPU_BINS)
 cuda: $(CUDA_BINS)
+
+# Build and run the hypersonic CUDA regression + unit test suite.
+# Requires a CUDA-capable GPU at runtime; writes a fresh baseline and then
+# verifies the same run against it (round-trip self-check).
+BASELINE ?= tau_hypersonic_cuda_baseline.txt
+TEST_STEPS ?= 24
+test: tau_hypersonic_cuda_tests
+	./tau_hypersonic_cuda_tests --steps $(TEST_STEPS) --write-baseline  --baseline $(BASELINE)
+	./tau_hypersonic_cuda_tests --steps $(TEST_STEPS) --verify-baseline --baseline $(BASELINE)
 
 # ---------------------------------------------------------------------------
 # CPU targets (gcc)
@@ -64,7 +76,7 @@ tau_burgers: tau_burgers.cu
 	$(NVCC) -std=c++17 -O3 -use_fast_math -arch=sm_86 -lineinfo -o $@ $< -lncursesw
 
 tgs: tau_gray_scott.cu
-	$(NVCC) -std=c++17 -ccbin g++-10 -O3 -use_fast_math -arch=sm_86 -lineinfo $< -lncursesw -o $@
+	$(NVCC) -std=c++17 -ccbin $(CCBIN) -O3 -use_fast_math -arch=sm_86 -lineinfo $< -lncursesw -o $@
 
 tau3d: tau_hypersonic_3d_cuda.cu
 	$(NVCC) -O3 -std=c++17 $< -o $@ -lineinfo
@@ -86,4 +98,4 @@ th3cs: th3cs.cu 4splat.c
 
 # ---------------------------------------------------------------------------
 clean:
-	$(RM) $(CPU_BINS) $(CUDA_BINS) th3cs
+	$(RM) $(CPU_BINS) $(CUDA_BINS) th3cs $(BASELINE)

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ tgs: tau_gray_scott.cu
 	$(NVCC) -std=c++17 -ccbin $(CCBIN) -O3 -use_fast_math -arch=sm_86 -lineinfo $< -lncursesw -o $@
 
 tau3d: tau_hypersonic_3d_cuda.cu
-	$(NVCC) -O3 -std=c++17 $< -o $@ -lineinfo
+	$(NVCC) -O3 -std=c++17 $< -o $@ -lineinfo -lraylib
 
 tau_2d_hypersonic_cuda: tau_hypersonic_cuda.cu
 	$(NVCC) -O3 -o $@ $< -std=c++17 -lraylib

--- a/tau_hypersonic_cuda_tests.cu
+++ b/tau_hypersonic_cuda_tests.cu
@@ -313,10 +313,11 @@ __global__ void k_test_hllc_consistency(double *out) {
   out[7] = Fy.E - Fy_ref.E;
 }
 
-int main(int argc, char **argv) {
-  RegressionOptions options{};
-  if (!parse_regression_options(argc, argv, &options))
-    return 2;
+__global__ void k_test_enforce_positive(double *out) {
+  Prim qc{1.0, 4.0, -2.0, 1.0};
+  Prim qm{-1.0, 8.0, -4.0, -3.0};
+  Prim qp{-2.0, -8.0, 4.0, -2.0};
+  enforce_positive_faces(qm, qc, qp);
 
   out[0] = qm.rho;
   out[1] = qm.p;
@@ -369,11 +370,12 @@ __global__ void k_test_neighbor_for_diff(Usoa U, const uint8_t *mask,
   out[3] = top_clamped.rho;
 }
 
-int main() {
-  TestStats stats{0, 0};
-  SimConfig cfg = default_config();
-  CK(cudaMemcpyToSymbol(d_cfg, &cfg, sizeof(SimConfig)));
+int main(int argc, char **argv) {
+  RegressionOptions options{};
+  if (!parse_regression_options(argc, argv, &options))
+    return 2;
 
+  TestStats stats{0, 0};
   SimConfig cfg = default_config();
   CK(cudaMemcpyToSymbol(d_cfg, &cfg, sizeof(SimConfig)));
 
@@ -455,6 +457,14 @@ int main() {
   alloc_Cs(&dYStateR, N);
   alloc_Cs(&dXFlux, (W + 1) * H);
   alloc_Cs(&dYFlux, W * (H + 1));
+  k_test_enforce_positive<<<1, 1>>>(d);
+  CK(cudaDeviceSynchronize());
+  CK(cudaMemcpy(h, d, 4 * sizeof(double), cudaMemcpyDeviceToHost));
+  CHECK_TRUE(stats, h[0] >= EPS_RHO, "enforce_positive_faces keeps qm rho > 0");
+  CHECK_TRUE(stats, h[1] >= EPS_P, "enforce_positive_faces keeps qm p > 0");
+  CHECK_TRUE(stats, h[2] >= EPS_RHO, "enforce_positive_faces keeps qp rho > 0");
+  CHECK_TRUE(stats, h[3] >= EPS_P, "enforce_positive_faces keeps qp p > 0");
+
   k_test_enforce_positive_no_change<<<1, 1>>>(d);
   CK(cudaDeviceSynchronize());
   CK(cudaMemcpy(h, d, 4 * sizeof(double), cudaMemcpyDeviceToHost));
@@ -551,35 +561,79 @@ int main() {
   free(hRho);
   free(hMx);
   free(hMy);
-  k_test_neighbors<<<1, 1>>>(U, dMask, d, x, y);
-  CK(cudaDeviceSynchronize());
-  CK(cudaMemcpy(h, d, 5 * sizeof(double), cudaMemcpyDeviceToHost));
-  Prim infl = inflow_state();
-  CHECK_NEAR(stats, h[0], infl.rho, 1e-12, "left boundary uses inflow rho");
-  CHECK_NEAR(stats, h[1], prim_to_cons(infl).mx, 1e-10,
-             "left boundary uses inflow momentum");
-  CHECK_NEAR(stats, h[2], 1.0, 1e-12, "right neighbor uses cell rho");
-  CHECK_NEAR(stats, h[3], 7.0, 1e-12, "right neighbor uses fluid state");
-  CHECK_NEAR(stats, h[4], -3.0, 1e-12,
-             "masked neighbor reflects no-slip momentum");
-
-  k_test_neighbor_for_diff<<<1, 1>>>(U, dMask, d, x, y);
-  CK(cudaDeviceSynchronize());
-  CK(cudaMemcpy(h, d, 4 * sizeof(double), cudaMemcpyDeviceToHost));
-  CHECK_NEAR(stats, h[0], infl.rho, 1e-12,
-             "neighbor_for_diff left boundary uses inflow rho");
-  CHECK_NEAR(stats, h[1], prim_to_cons(infl).mx, 1e-10,
-             "neighbor_for_diff left boundary uses inflow mx");
-  CHECK_NEAR(stats, h[2], -3.0, 1e-12,
-             "neighbor_for_diff masked cell reflects momentum");
-  CHECK_NEAR(stats, h[3], 1.0, 1e-12,
-             "neighbor_for_diff clamps y index before lookup");
-
-  free(hrho);
-  free(hmx);
-  free(hmy);
   free(hE);
   free(hMask);
+
+  // Neighbor lookups on a hand-crafted field: left column hits the inflow
+  // boundary, the right neighbor reads a fluid cell, and the cell above is a
+  // wall that should reflect momentum (no-slip).
+  {
+    Usoa U{};
+    alloc_Us(&U, N);
+    uint8_t *dMaskN = nullptr;
+    CK(cudaMalloc(&dMaskN, (size_t)N * sizeof(uint8_t)));
+
+    double *nrho = (double *)malloc((size_t)N * sizeof(double));
+    double *nmx = (double *)malloc((size_t)N * sizeof(double));
+    double *nmy = (double *)malloc((size_t)N * sizeof(double));
+    double *nE = (double *)malloc((size_t)N * sizeof(double));
+    uint8_t *nmask = (uint8_t *)malloc((size_t)N * sizeof(uint8_t));
+
+    for (int i = 0; i < N; i++) {
+      nrho[i] = 1.0;
+      nmx[i] = 0.0;
+      nmy[i] = 0.0;
+      nE[i] = prim_to_cons(Prim{1.0, 0.0, 0.0, 1.0}).E;
+      nmask[i] = 0;
+    }
+
+    int x = 0, y = 10;
+    int i_center = y * W + x;
+    int i_right = y * W + (x + 1);
+    int i_up = (y + 1) * W + x;
+
+    nmx[i_center] = 3.0;
+    nmx[i_right] = 7.0;
+    nmask[i_up] = 1;
+
+    CK(cudaMemcpy(U.rho, nrho, (size_t)N * sizeof(double), cudaMemcpyHostToDevice));
+    CK(cudaMemcpy(U.mx, nmx, (size_t)N * sizeof(double), cudaMemcpyHostToDevice));
+    CK(cudaMemcpy(U.my, nmy, (size_t)N * sizeof(double), cudaMemcpyHostToDevice));
+    CK(cudaMemcpy(U.E, nE, (size_t)N * sizeof(double), cudaMemcpyHostToDevice));
+    CK(cudaMemcpy(dMaskN, nmask, (size_t)N * sizeof(uint8_t), cudaMemcpyHostToDevice));
+
+    k_test_neighbors<<<1, 1>>>(U, dMaskN, d, x, y);
+    CK(cudaDeviceSynchronize());
+    CK(cudaMemcpy(h, d, 5 * sizeof(double), cudaMemcpyDeviceToHost));
+    Prim infl = inflow_state();
+    CHECK_NEAR(stats, h[0], infl.rho, 1e-12, "left boundary uses inflow rho");
+    CHECK_NEAR(stats, h[1], prim_to_cons(infl).mx, 1e-10,
+               "left boundary uses inflow momentum");
+    CHECK_NEAR(stats, h[2], 1.0, 1e-12, "right neighbor uses cell rho");
+    CHECK_NEAR(stats, h[3], 7.0, 1e-12, "right neighbor uses fluid state");
+    CHECK_NEAR(stats, h[4], -3.0, 1e-12,
+               "masked neighbor reflects no-slip momentum");
+
+    k_test_neighbor_for_diff<<<1, 1>>>(U, dMaskN, d, x, y);
+    CK(cudaDeviceSynchronize());
+    CK(cudaMemcpy(h, d, 4 * sizeof(double), cudaMemcpyDeviceToHost));
+    CHECK_NEAR(stats, h[0], infl.rho, 1e-12,
+               "neighbor_for_diff left boundary uses inflow rho");
+    CHECK_NEAR(stats, h[1], prim_to_cons(infl).mx, 1e-10,
+               "neighbor_for_diff left boundary uses inflow mx");
+    CHECK_NEAR(stats, h[2], -3.0, 1e-12,
+               "neighbor_for_diff masked cell reflects momentum");
+    CHECK_NEAR(stats, h[3], 1.0, 1e-12,
+               "neighbor_for_diff clamps y index before lookup");
+
+    free(nrho);
+    free(nmx);
+    free(nmy);
+    free(nE);
+    free(nmask);
+    cudaFree(dMaskN);
+    free_Us(&U);
+  }
 
   cudaFree(dMaxSpeed);
   cudaFree(dBlockSpeedMax);

--- a/tau_hypersonic_cuda_tests.cu
+++ b/tau_hypersonic_cuda_tests.cu
@@ -583,7 +583,7 @@ int main(int argc, char **argv) {
       nrho[i] = 1.0;
       nmx[i] = 0.0;
       nmy[i] = 0.0;
-      nE[i] = prim_to_cons(Prim{1.0, 0.0, 0.0, 1.0}).E;
+      nE[i] = 1.0 / (cfg.gamma - 1.0); // rest state (rho=1, u=v=0, p=1)
       nmask[i] = 0;
     }
 
@@ -596,6 +596,11 @@ int main(int argc, char **argv) {
     nmx[i_right] = 7.0;
     nmask[i_up] = 1;
 
+    // inflow_state()/prim_to_cons are __device__ functions; mirror their values
+    // on the host (see k_test_inflow_state expectations above).
+    const double infl_rho = 1.0;
+    const double infl_mx = cfg.inflow_mach * std::sqrt(cfg.gamma);
+
     CK(cudaMemcpy(U.rho, nrho, (size_t)N * sizeof(double), cudaMemcpyHostToDevice));
     CK(cudaMemcpy(U.mx, nmx, (size_t)N * sizeof(double), cudaMemcpyHostToDevice));
     CK(cudaMemcpy(U.my, nmy, (size_t)N * sizeof(double), cudaMemcpyHostToDevice));
@@ -605,9 +610,8 @@ int main(int argc, char **argv) {
     k_test_neighbors<<<1, 1>>>(U, dMaskN, d, x, y);
     CK(cudaDeviceSynchronize());
     CK(cudaMemcpy(h, d, 5 * sizeof(double), cudaMemcpyDeviceToHost));
-    Prim infl = inflow_state();
-    CHECK_NEAR(stats, h[0], infl.rho, 1e-12, "left boundary uses inflow rho");
-    CHECK_NEAR(stats, h[1], prim_to_cons(infl).mx, 1e-10,
+    CHECK_NEAR(stats, h[0], infl_rho, 1e-12, "left boundary uses inflow rho");
+    CHECK_NEAR(stats, h[1], infl_mx, 1e-10,
                "left boundary uses inflow momentum");
     CHECK_NEAR(stats, h[2], 1.0, 1e-12, "right neighbor uses cell rho");
     CHECK_NEAR(stats, h[3], 7.0, 1e-12, "right neighbor uses fluid state");
@@ -617,9 +621,9 @@ int main(int argc, char **argv) {
     k_test_neighbor_for_diff<<<1, 1>>>(U, dMaskN, d, x, y);
     CK(cudaDeviceSynchronize());
     CK(cudaMemcpy(h, d, 4 * sizeof(double), cudaMemcpyDeviceToHost));
-    CHECK_NEAR(stats, h[0], infl.rho, 1e-12,
+    CHECK_NEAR(stats, h[0], infl_rho, 1e-12,
                "neighbor_for_diff left boundary uses inflow rho");
-    CHECK_NEAR(stats, h[1], prim_to_cons(infl).mx, 1e-10,
+    CHECK_NEAR(stats, h[1], infl_mx, 1e-10,
                "neighbor_for_diff left boundary uses inflow mx");
     CHECK_NEAR(stats, h[2], -3.0, 1e-12,
                "neighbor_for_diff masked cell reflects momentum");


### PR DESCRIPTION
Follow-up to #48 (the single Makefile), which merged before this work was pushed. These commits sit on top of that merged Makefile and add CI plus the fixes needed to make the whole tree build in a clean environment.

## What's here

**GitHub Actions CI** (`.github/workflows/ci.yml`), two jobs on push/PR:
- **Build CPU demos (gcc)** — installs ncurses + the official raylib 5.5 release, runs `make cpu`.
- **Build CUDA demos + tests (nvcc)** — installs the CUDA toolkit (nvcc/cudart only, no driver) + raylib, runs `make cuda`, and runs `make test` only when a GPU is present (hosted runners have none, so the tests compile in CI and execute on a GPU machine).

**Repair of `tau_hypersonic_cuda_tests.cu`** — the file did not compile on `main`: an earlier merge (`4c4870a`) fused two divergent test `main()`s, leaving a duplicate `main()`, a kernel whose header was overwritten, dropped neighbor-test field setup, and undefined identifiers. Reconstructed `main()` from both parent commits so it runs the unit tests, neighbor-lookup tests, and the regression baseline check; restored the `k_test_enforce_positive` kernel; and compute the inflow reference values on the host (the solver's `inflow_state`/`prim_to_cons` are `__device__`-only).

**Makefile** — added a `make test` target (write-then-verify baseline round-trip), made the gray-scott host compiler overridable (`CCBIN`, default `g++-10`), and added `-lraylib` to the `tau3d` recipe (its source uses raylib but the in-file build line omitted the lib).

## Status

CI is green: both jobs build all CPU and CUDA targets and the test harness. The regression/unit tests compile in CI but only execute on a machine with a CUDA GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTNkVWay1h9bBbrbZ973Hs)_